### PR TITLE
reduce number of entities

### DIFF
--- a/src/condor_tensorflow/__init__.py
+++ b/src/condor_tensorflow/__init__.py
@@ -1,15 +1,10 @@
 from .version import __version__
 
 from .loss import CondorNegLogLikelihood
-from .loss import SparseCondorNegLogLikelihood
 from .loss import CondorOrdinalCrossEntropy
-from .loss import SparseCondorOrdinalCrossEntropy
 from .loss import OrdinalEarthMoversDistance
-from .loss import SparseOrdinalEarthMoversDistance
 from .metrics import OrdinalMeanAbsoluteError
-from .metrics import SparseOrdinalMeanAbsoluteError
 from .metrics import OrdinalAccuracy
-from .metrics import SparseOrdinalAccuracy
 from .activations import ordinal_softmax
 from .labelencoder import CondorOrdinalEncoder
 
@@ -17,15 +12,10 @@ from .labelencoder import CondorOrdinalEncoder
 # be able to access:
 __all__ = [
     'CondorNegLogLikelihood',
-    'SparseCondorNegLogLikelihood',
     'OrdinalAccuracy',
-    'SparseOrdinalAccuracy',
     'OrdinalMeanAbsoluteError',
-    'SparseOrdinalMeanAbsoluteError',
     'OrdinalEarthMoversDistance',
-    'SparseOrdinalEarthMoversDistance',
     'CondorOrdinalCrossEntropy',
-    'SparseCondorOrdinalCrossEntropy',
     'ordinal_softmax',
     'CondorOrdinalEncoder',
 ]

--- a/src/condor_tensorflow/__init__.py
+++ b/src/condor_tensorflow/__init__.py
@@ -1,3 +1,6 @@
+"""
+Condor-TensorFlow - Condor ordinal loss regression
+"""
 from .version import __version__
 
 from .loss import CondorNegLogLikelihood

--- a/src/condor_tensorflow/loss.py
+++ b/src/condor_tensorflow/loss.py
@@ -87,6 +87,8 @@ encode_ordinal_labels = encode_ordinal_labels_v2
 
 class CondorNegLogLikelihood(losses.Loss):
 
+    """Ordinal Negative Log-likelihood Loss
+    """
     sparse: bool
     from_type: str
 
@@ -203,6 +205,9 @@ class CondorNegLogLikelihood(losses.Loss):
 
 
 class CondorOrdinalCrossEntropy(losses.Loss):
+
+    """Ordinal cross-entropy loss
+    """
 
     importance_weights: Optional[TensorLike]
     sparse: bool

--- a/src/condor_tensorflow/loss.py
+++ b/src/condor_tensorflow/loss.py
@@ -344,7 +344,7 @@ class OrdinalEarthMoversDistance(losses.Loss):
         """Computes mean absolute error for ordinal labels.
 
         Args:
-          y_true: Cumulatiuve logits from CondorOrdinal layer.
+          y_true: Cumulative logits from CondorOrdinal layer.
           y_pred: CondorOrdinal Encoded Labels.
         """
 
@@ -364,11 +364,11 @@ class OrdinalEarthMoversDistance(losses.Loss):
         # remove all dimensions of size 1 (e.g., from [[1], [2]], to [1, 2])
         # y_true = tf.squeeze(y_true)
 
-        y_dist = tf.map_fn(
-            fn=lambda y: tf.abs(y - tf.range(num_classes, dtype=y_pred.dtype)),
-            elems=y_true,
-        )
-
+        # y_dist = tf.map_fn(
+        #     fn=lambda y: tf.abs(y - tf.range(num_classes, dtype=y_pred.dtype)),
+        #     elems=y_true,
+        # )
+        y_dist = tf.abs(y_true - tf.range(num_classes, dtype=y_pred.dtype))
         return tf.reduce_sum(tf.math.multiply(y_dist, cum_probs), axis=1)
 
     def get_config(self) -> Dict[str, Any]:

--- a/src/condor_tensorflow/loss.py
+++ b/src/condor_tensorflow/loss.py
@@ -13,24 +13,6 @@ from .activations import ordinal_softmax
 from .types import TensorLike, IntArray, FloatArray
 
 
-def encode_ordinal_labels_numpy(
-        array: IntArray,
-        num_classes: int,
-        dtype: type = np.float32) -> FloatArray:
-    """Encoder ordinal data to one-hot type
-
-    Example:
-
-        >>> labels = np.arange(3)
-        >>> encode_ordinal_labels_numpy(labels, num_classes=3)
-        array([[0., 0.],
-               [1., 0.],
-               [1., 1.]], dtype=float32)
-    """
-    result = array[:, None] > np.arange(num_classes)[:-1]
-    return result.astype(dtype)
-
-
 def encode_ordinal_labels_v1(
         labels: tf.Tensor,
         num_classes: int,

--- a/src/condor_tensorflow/loss.py
+++ b/src/condor_tensorflow/loss.py
@@ -85,6 +85,7 @@ def encode_ordinal_labels_v2(
 encode_ordinal_labels = encode_ordinal_labels_v2
 
 
+@tf.keras.utils.register_keras_serializable(package="condor_tensorflow")
 class CondorNegLogLikelihood(losses.Loss):
 
     """Ordinal Negative Log-likelihood Loss
@@ -204,6 +205,7 @@ class CondorNegLogLikelihood(losses.Loss):
         return {**base_config, **config}
 
 
+@tf.keras.utils.register_keras_serializable(package="condor_tensorflow")
 class CondorOrdinalCrossEntropy(losses.Loss):
 
     """Ordinal cross-entropy loss
@@ -315,6 +317,7 @@ class CondorOrdinalCrossEntropy(losses.Loss):
         return {**base_config, **config}
 
 
+@tf.keras.utils.register_keras_serializable(package="condor_tensorflow")
 class OrdinalEarthMoversDistance(losses.Loss):
     """Computes earth movers distance for ordinal labels."""
 

--- a/src/condor_tensorflow/loss.py
+++ b/src/condor_tensorflow/loss.py
@@ -138,7 +138,7 @@ class CondorNegLogLikelihood(losses.Loss):
             Loss vector, note that tensorflow will reduce it to a single number
             automatically.
         """
-        with ops.name_scope(name, "logistic_loss", [logits, labels]) as name:
+        with ops.name_scope(name, "logistic_loss", [logits, labels]) as scope:
             if isinstance(logits, tf.Tensor):
                 logits = tf.cast(logits, dtype=tf.float32, name="logits")
             else:
@@ -167,7 +167,7 @@ class CondorNegLogLikelihood(losses.Loss):
                 math_ops.log1p(math_ops.exp(neg_abs_logits)),
             )
             return tf.math.reduce_sum(
-                array_ops.where(cond2, temp, zeros), axis=1, name=name
+                array_ops.where(cond2, temp, zeros), axis=1, name=scope
             )
 
     # Following https://www.tensorflow.org/api_docs/python/tf/keras/losses/Loss

--- a/src/condor_tensorflow/loss.py
+++ b/src/condor_tensorflow/loss.py
@@ -2,6 +2,7 @@
 Loss function definitions
 """
 from typing import Dict, Any, Optional
+import numpy as np
 import tensorflow as tf
 from tensorflow.python.framework import ops, dtypes
 from tensorflow.python.ops import array_ops, math_ops
@@ -9,7 +10,26 @@ from tensorflow.keras import losses
 from tensorflow.keras import backend as K
 
 from .activations import ordinal_softmax
-from .types import TensorLike
+from .types import TensorLike, IntArray, FloatArray
+
+
+def encode_ordinal_labels_numpy(
+        array: IntArray,
+        num_classes: int,
+        dtype: type = np.float32) -> FloatArray:
+    """Encoder ordinal data to one-hot type
+
+    Example:
+
+        >>> labels = np.arange(3)
+        >>> encode_ordinal_labels_numpy(labels, num_classes=3)
+        array([[0., 0.],
+               [1., 0.],
+               [1., 1.]], dtype=float32)
+    """
+    result = array[:, None] > np.arange(num_classes)
+    result = result[:, :-1]
+    return result.astype(dtype)
 
 
 def encode_ordinal_labels_v1(
@@ -28,7 +48,8 @@ def encode_ordinal_labels_v1(
 
     Example:
 
-        >>> encode_ordinal_labels_v1(tf.constant([0, 1, 2], dtype=tf.float32), num_classes=3)
+        >>> labels = tf.constant(np.arange(3), dtype=tf.float32)
+        >>> encode_ordinal_labels_v1(labels, num_classes=3)
         <tf.Tensor: shape=(3, 2), dtype=float32, numpy=
         array([[0., 0.],
                [1., 0.],
@@ -68,7 +89,8 @@ def encode_ordinal_labels_v2(
 
     Example:
 
-        >>> encode_ordinal_labels_v2([0, 1, 2], num_classes=3)
+        >>> labels = tf.constant(np.arange(3), dtype=tf.float32)
+        >>> encode_ordinal_labels_v2(labels, num_classes=3)
         <tf.Tensor: shape=(3, 2), dtype=float32, numpy=
         array([[0., 0.],
                [1., 0.],

--- a/src/condor_tensorflow/loss.py
+++ b/src/condor_tensorflow/loss.py
@@ -48,6 +48,7 @@ def encode_ordinal_labels_v1(
         num_zeros = num_classes - 1 - tf.cast(tf.squeeze(label), tf.int32)
         zero_vec = tf.zeros(shape=(num_zeros), dtype=tf.int32)
         return tf.cast(tf.concat([label_vec, zero_vec], 0), dtype)
+    labels = tf.cast(labels, tf.float32)
     return tf.map_fn(_func, labels)
 
 

--- a/src/condor_tensorflow/loss.py
+++ b/src/condor_tensorflow/loss.py
@@ -148,6 +148,8 @@ class CondorNegLogLikelihood(losses.Loss):
                 labs = tf.cast(labels, dtype=tf.float32, name="labs")
             else:
                 labs = ops.convert_to_tensor(labels, dtype=tf.float32, name="labs")
+            # line below makes loss work with 3D tensors
+            # pi_labels = tf.concat([tf.ones((tf.shape(labs)[0], 1)), labs[:, -1][:, :-1]], 1)
             pi_labels = tf.concat([tf.ones((tf.shape(labs)[0], 1)), labs[:, :-1]], 1)
 
             # The logistic loss formula from above is
@@ -168,6 +170,8 @@ class CondorNegLogLikelihood(losses.Loss):
                 math_ops.log1p(math_ops.exp(neg_abs_logits)),
             )
             return tf.math.reduce_sum(
+                # line below makes loss work with 3D tensors
+                # array_ops.where(cond2, temp[:, -1], zeros), axis=1, name=scope
                 array_ops.where(cond2, temp, zeros), axis=1, name=scope
             )
 

--- a/src/condor_tensorflow/loss.py
+++ b/src/condor_tensorflow/loss.py
@@ -364,10 +364,6 @@ class OrdinalEarthMoversDistance(losses.Loss):
         # remove all dimensions of size 1 (e.g., from [[1], [2]], to [1, 2])
         # y_true = tf.squeeze(y_true)
 
-        # y_dist = tf.map_fn(
-        #     fn=lambda y: tf.abs(y - tf.range(num_classes, dtype=y_pred.dtype)),
-        #     elems=y_true,
-        # )
         y_dist = tf.abs(y_true - tf.range(num_classes, dtype=y_pred.dtype))
         return tf.reduce_sum(tf.math.multiply(y_dist, cum_probs), axis=1)
 

--- a/src/condor_tensorflow/loss.py
+++ b/src/condor_tensorflow/loss.py
@@ -27,8 +27,7 @@ def encode_ordinal_labels_numpy(
                [1., 0.],
                [1., 1.]], dtype=float32)
     """
-    result = array[:, None] > np.arange(num_classes)
-    result = result[:, :-1]
+    result = array[:, None] > np.arange(num_classes)[:-1]
     return result.astype(dtype)
 
 

--- a/src/condor_tensorflow/metrics.py
+++ b/src/condor_tensorflow/metrics.py
@@ -9,12 +9,16 @@ from tensorflow.keras import metrics
 class OrdinalMeanAbsoluteError(metrics.Metric):
     """Computes mean absolute error for ordinal labels."""
 
+    sparse: bool
+
     def __init__(
             self,
+            sparse: bool = False,
             name: str = "mean_absolute_error_labels",
             **kwargs: Any):
         """Creates a `OrdinalMeanAbsoluteError` instance."""
         super().__init__(name=name, **kwargs)
+        self.sparse = sparse
         self.maes = self.add_weight(name='maes', initializer='zeros')
         self.count = self.add_weight(name='count', initializer='zeros')
 
@@ -46,7 +50,12 @@ class OrdinalMeanAbsoluteError(metrics.Metric):
         # passed.
         labels_v2 = tf.reduce_sum(above_thresh, axis=1)
 
-        y_true = tf.cast(tf.reduce_sum(y_true, axis=1), y_pred.dtype)
+        if not self.sparse:
+            # Sum across columns to estimate how many cumulative thresholds are
+            # passed.
+            y_true = tf.reduce_sum(y_true, axis=1)
+
+        y_true = tf.cast(y_true, y_pred.dtype)
 
         # remove all dimensions of size 1 (e.g., from [[1], [2]], to [1, 2])
         y_true = tf.squeeze(y_true)
@@ -72,72 +81,22 @@ class OrdinalMeanAbsoluteError(metrics.Metric):
 
     def get_config(self) -> Dict[str, Any]:
         """Returns the serializable config of the metric."""
+        config = {
+            'sparse': self.sparse,
+        }
         base_config = super().get_config()
-        return {**base_config}
-
-
-class SparseOrdinalMeanAbsoluteError(OrdinalMeanAbsoluteError):
-    """Computes mean absolute error for ordinal labels."""
-
-    def __init__(
-            self,
-            name: str = "mean_absolute_error_labels",
-            **kwargs: Any):
-        """Creates a `OrdinalMeanAbsoluteError` instance."""
-        super().__init__(name=name, **kwargs)
-
-    def update_state(
-            self,
-            y_true: tf.Tensor,
-            y_pred: tf.Tensor,
-            sample_weight: Optional[tf.Tensor] = None) -> None:
-        """Computes mean absolute error for ordinal labels.
-
-        Args:
-          y_true: Cumulatiuve logits from CondorOrdinal layer.
-          y_pred: CondorOrdinal Encoded Labels.
-          sample_weight (optional): Not implemented.
-        """
-
-        # Predict the label as in Cao et al. - using cumulative probabilities
-        cum_probs = tf.math.cumprod(
-            tf.math.sigmoid(y_pred),
-            axis=1)  # tf.map_fn(tf.math.sigmoid, y_pred)
-
-        # Calculate the labels using the style of Cao et al.
-        above_thresh = tf.map_fn(
-            lambda x: tf.cast(
-                x > 0.5,
-                tf.float32),
-            cum_probs)
-
-        # Sum across columns to estimate how many cumulative thresholds are
-        # passed.
-        labels_v2 = tf.reduce_sum(above_thresh, axis=1)
-
-        y_true = tf.cast(y_true, y_pred.dtype)
-
-        # remove all dimensions of size 1 (e.g., from [[1], [2]], to [1, 2])
-        y_true = tf.squeeze(y_true)
-
-        if sample_weight is not None:
-            values = tf.abs(y_true - labels_v2)
-            sample_weight = tf.cast(tf.squeeze(sample_weight), y_pred.dtype)
-            sample_weight = tf.broadcast_to(sample_weight, values.shape)
-            values = tf.multiply(values, sample_weight)
-            self.maes.assign_add(tf.reduce_sum(values))
-            self.count.assign_add(tf.reduce_sum(sample_weight))
-        else:
-            self.maes.assign_add(tf.reduce_sum(tf.abs(y_true - labels_v2)))
-            self.count.assign_add(tf.cast(tf.size(y_true), tf.float32))
+        return {**base_config, **config}
 
 
 class OrdinalAccuracy(metrics.Metric):
     """Computes accuracy for ordinal labels (tolerance is allowed rank
     distance to be considered 'correct' predictions)."""
 
+    sparse: bool
+
     def __init__(
             self,
+            sparse: bool = False,
             name: Optional[str] = None,
             tolerance: float = 0.,
             **kwargs: Any) -> None:
@@ -145,6 +104,7 @@ class OrdinalAccuracy(metrics.Metric):
         if name is None:
             name = f"ordinal_accuracy_tol{tolerance}"
         super().__init__(name=name, **kwargs)
+        self.sparse = sparse
         self.accs = self.add_weight(name='accs', initializer='zeros')
         self.count = self.add_weight(name='count', initializer='zeros')
         self.tolerance = tolerance
@@ -178,7 +138,10 @@ class OrdinalAccuracy(metrics.Metric):
         # passed.
         labels_v2 = tf.reduce_sum(above_thresh, axis=1)
 
-        y_true = tf.cast(tf.reduce_sum(y_true, axis=1), y_pred.dtype)
+        if not self.sparse:
+            y_true = tf.reduce_sum(y_true, axis=1)
+
+        y_true = tf.cast(y_true, y_pred.dtype)
 
         # remove all dimensions of size 1 (e.g., from [[1], [2]], to [1, 2])
         y_true = tf.squeeze(y_true)
@@ -208,60 +171,9 @@ class OrdinalAccuracy(metrics.Metric):
 
     def get_config(self) -> Dict[str, Any]:
         """Returns the serializable config of the metric."""
-        config = {'tolerance': self.tolerance}
+        config = {
+            'sparse': self.sparse,
+            'tolerance': self.tolerance,
+        }
         base_config = super().get_config()
         return {**base_config, **config}
-
-
-class SparseOrdinalAccuracy(OrdinalAccuracy):
-    """Computes accuracy for ordinal labels (tolerance is allowed rank
-    distance to be considered 'correct' predictions)."""
-
-    def update_state(
-            self,
-            y_true: tf.Tensor,
-            y_pred: tf.Tensor,
-            sample_weight: Optional[tf.Tensor] = None) -> None:
-        """Computes accuracy for ordinal labels.
-
-        Args:
-          y_true: Cumulatiuve logits from CondorOrdinal layer.
-          y_pred: CondorOrdinal Encoded Labels.
-          sample_weight (optional): Not implemented.
-        """
-
-        # Predict the label as in Cao et al. - using cumulative probabilities
-        cum_probs = tf.math.cumprod(
-            tf.math.sigmoid(y_pred),
-            axis=1)  # tf.map_fn(tf.math.sigmoid, y_pred)
-
-        # Calculate the labels using the style of Cao et al.
-        above_thresh = tf.map_fn(
-            lambda x: tf.cast(
-                x > 0.5,
-                tf.float32),
-            cum_probs)
-
-        # Sum across columns to estimate how many cumulative thresholds are
-        # passed.
-        labels_v2 = tf.reduce_sum(above_thresh, axis=1)
-
-        y_true = tf.cast(y_true, y_pred.dtype)
-
-        # remove all dimensions of size 1 (e.g., from [[1], [2]], to [1, 2])
-        y_true = tf.squeeze(y_true)
-
-        if sample_weight is not None:
-            values = tf.cast(tf.less_equal(
-                tf.abs(y_true - labels_v2), tf.cast(self.tolerance, y_pred.dtype)),
-                y_pred.dtype)
-            sample_weight = tf.cast(tf.squeeze(sample_weight), y_pred.dtype)
-            sample_weight = tf.broadcast_to(sample_weight, values.shape)
-            values = tf.multiply(values, sample_weight)
-            self.accs.assign_add(tf.reduce_sum(values))
-            self.count.assign_add(tf.reduce_sum(sample_weight))
-        else:
-            self.accs.assign_add(tf.reduce_sum(tf.cast(tf.less_equal(
-                tf.abs(y_true - labels_v2), tf.cast(self.tolerance, y_pred.dtype)),
-                y_pred.dtype)))
-            self.count.assign_add(tf.cast(tf.size(y_true), tf.float32))

--- a/src/condor_tensorflow/metrics.py
+++ b/src/condor_tensorflow/metrics.py
@@ -41,9 +41,7 @@ class OrdinalMeanAbsoluteError(metrics.Metric):
 
         # Calculate the labels using the style of Cao et al.
         above_thresh = tf.map_fn(
-            lambda x: tf.cast(
-                x > 0.5,
-                tf.float32),
+            lambda x: tf.cast(x > 0.5, tf.float32),
             cum_probs)
 
         # Sum across columns to estimate how many cumulative thresholds are
@@ -130,9 +128,7 @@ class OrdinalAccuracy(metrics.Metric):
 
         # Calculate the labels using the style of Cao et al.
         above_thresh = tf.map_fn(
-            lambda x: tf.cast(
-                x > 0.5,
-                tf.float32),
+            lambda x: tf.cast(x > 0.5, tf.float32),
             cum_probs)
 
         # Sum across columns to estimate how many cumulative thresholds are

--- a/src/condor_tensorflow/metrics.py
+++ b/src/condor_tensorflow/metrics.py
@@ -6,6 +6,7 @@ import tensorflow as tf
 from tensorflow.keras import metrics
 
 
+@tf.keras.utils.register_keras_serializable(package="condor_tensorflow")
 class OrdinalMeanAbsoluteError(metrics.Metric):
     """Computes mean absolute error for ordinal labels."""
 
@@ -87,6 +88,7 @@ class OrdinalMeanAbsoluteError(metrics.Metric):
         return {**base_config, **config}
 
 
+@tf.keras.utils.register_keras_serializable(package="condor_tensorflow")
 class OrdinalAccuracy(metrics.Metric):
     """Computes accuracy for ordinal labels (tolerance is allowed rank
     distance to be considered 'correct' predictions)."""

--- a/src/condor_tensorflow/metrics.py
+++ b/src/condor_tensorflow/metrics.py
@@ -72,6 +72,7 @@ class OrdinalMeanAbsoluteError(metrics.Metric):
             self.count.assign_add(tf.cast(tf.size(y_true), tf.float32))
 
     def result(self) -> tf.Tensor:
+        """Return the scalar metric result"""
         return tf.math.divide_no_nan(self.maes, self.count)
 
     def reset_state(self) -> None:
@@ -162,6 +163,7 @@ class OrdinalAccuracy(metrics.Metric):
             self.count.assign_add(tf.cast(tf.size(y_true), tf.float32))
 
     def result(self) -> tf.Tensor:
+        """Return the scalar metric result"""
         return tf.math.divide_no_nan(self.accs, self.count)
 
     def reset_state(self) -> None:

--- a/src/condor_tensorflow/tests/test_labelencoder.py
+++ b/src/condor_tensorflow/tests/test_labelencoder.py
@@ -1,14 +1,16 @@
-from condor_tensorflow.labelencoder import CondorOrdinalEncoder
-import pytest
-import tensorflow as tf
+"""
+Test module for LabelEncoder
+"""
+# pylint: disable=missing-function-docstring
 import numpy as np
-import pandas as pd
+
+from condor_tensorflow.labelencoder import CondorOrdinalEncoder
 
 
 def test_labelencoder_basic() -> None:
-    NUM_CLASSES = 5
-    labels = np.arange(NUM_CLASSES)
-    enc_labs = CondorOrdinalEncoder(nclasses=NUM_CLASSES).fit_transform(labels)
+    num_classes = 5
+    labels = np.arange(num_classes)
+    enc_labs = CondorOrdinalEncoder(nclasses=num_classes).fit_transform(labels)
     expected = np.array([[0., 0., 0., 0.],
                          [1., 0., 0., 0.],
                          [1., 1., 0., 0.],

--- a/src/condor_tensorflow/tests/test_loss.py
+++ b/src/condor_tensorflow/tests/test_loss.py
@@ -1,7 +1,8 @@
 """
-Unit tests for loss.py module
+Unit tests for ordinal loss module
 """
-import pytest
+# pylint: disable=invalid-name
+# pylint: disable=missing-function-docstring
 import tensorflow as tf
 
 from condor_tensorflow.loss import CondorNegLogLikelihood
@@ -15,11 +16,13 @@ def test_CondorNegLogLikelihood() -> None:
     expect = tf.constant(1.6265235)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_SparseCondorNegLogLikelihood() -> None:
     loss = CondorNegLogLikelihood(sparse=True)
     val = loss(tf.constant([2]), tf.constant([[-1., 1.]]))
     expect = tf.constant(1.6265235)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_CondorOrdinalCrossEntropy() -> None:
     loss = CondorOrdinalCrossEntropy()
@@ -27,17 +30,20 @@ def test_CondorOrdinalCrossEntropy() -> None:
     expect = tf.constant(2.9397845)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_SparseCondorOrdinalCrossEntropy() -> None:
     loss = CondorOrdinalCrossEntropy(sparse=True)
     val = loss(tf.constant([2]), tf.constant([[-1., 1.]]))
     expect = tf.constant(2.9397845)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_OrdinalEarthMoversDistance() -> None:
     loss = OrdinalEarthMoversDistance()
     val = loss(tf.constant([[1., 1.]]), tf.constant([[-1., 1.]]))
     expect = tf.constant(1.5344467)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_SparseOrdinalEarthMoversDistance() -> None:
     loss = OrdinalEarthMoversDistance(sparse=True)

--- a/src/condor_tensorflow/tests/test_loss.py
+++ b/src/condor_tensorflow/tests/test_loss.py
@@ -1,11 +1,12 @@
-from condor_tensorflow.loss import CondorNegLogLikelihood
-from condor_tensorflow.loss import SparseCondorNegLogLikelihood
-from condor_tensorflow.loss import CondorOrdinalCrossEntropy
-from condor_tensorflow.loss import SparseCondorOrdinalCrossEntropy
-from condor_tensorflow.loss import OrdinalEarthMoversDistance
-from condor_tensorflow.loss import SparseOrdinalEarthMoversDistance
+"""
+Unit tests for loss.py module
+"""
 import pytest
 import tensorflow as tf
+
+from condor_tensorflow.loss import CondorNegLogLikelihood
+from condor_tensorflow.loss import CondorOrdinalCrossEntropy
+from condor_tensorflow.loss import OrdinalEarthMoversDistance
 
 
 def test_CondorNegLogLikelihood() -> None:
@@ -15,7 +16,7 @@ def test_CondorNegLogLikelihood() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseCondorNegLogLikelihood() -> None:
-    loss = SparseCondorNegLogLikelihood()
+    loss = CondorNegLogLikelihood(sparse=True)
     val = loss(tf.constant([2]), tf.constant([[-1., 1.]]))
     expect = tf.constant(1.6265235)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
@@ -27,7 +28,7 @@ def test_CondorOrdinalCrossEntropy() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseCondorOrdinalCrossEntropy() -> None:
-    loss = SparseCondorOrdinalCrossEntropy()
+    loss = CondorOrdinalCrossEntropy(sparse=True)
     val = loss(tf.constant([2]), tf.constant([[-1., 1.]]))
     expect = tf.constant(2.9397845)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
@@ -39,7 +40,7 @@ def test_OrdinalEarthMoversDistance() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalEarthMoversDistance() -> None:
-    loss = SparseOrdinalEarthMoversDistance()
+    loss = OrdinalEarthMoversDistance(sparse=True)
     val = loss(tf.constant([2]), tf.constant([[-1., 1.]]))
     expect = tf.constant(1.5344467)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)

--- a/src/condor_tensorflow/tests/test_metrics.py
+++ b/src/condor_tensorflow/tests/test_metrics.py
@@ -1,4 +1,8 @@
-import pytest
+"""
+Unit tests for ordinal metrics module
+"""
+# pylint: disable=invalid-name
+# pylint: disable=missing-function-docstring
 import tensorflow as tf
 
 from condor_tensorflow.metrics import OrdinalMeanAbsoluteError
@@ -11,11 +15,13 @@ def test_OrdinalMeanAbsoluteError() -> None:
     expect = tf.constant(2.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_SparseOrdinalMeanAbsoluteError() -> None:
     loss = OrdinalMeanAbsoluteError(sparse=True)
     val = loss(tf.constant([2]), tf.constant([[-1., 1.]]))
     expect = tf.constant(2.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_OrdinalMeanAbsoluteError1() -> None:
     loss = OrdinalMeanAbsoluteError()
@@ -23,11 +29,13 @@ def test_OrdinalMeanAbsoluteError1() -> None:
     expect = tf.constant(1.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_SparseOrdinalMeanAbsoluteError1() -> None:
     loss = OrdinalMeanAbsoluteError(sparse=True)
     val = loss(tf.constant([1]), tf.constant([[-1., 1.]]))
     expect = tf.constant(1.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_OrdinalMeanAbsoluteError2() -> None:
     loss = OrdinalMeanAbsoluteError()
@@ -35,11 +43,13 @@ def test_OrdinalMeanAbsoluteError2() -> None:
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_SparseOrdinalMeanAbsoluteError2() -> None:
     loss = OrdinalMeanAbsoluteError(sparse=True)
     val = loss(tf.constant([0]), tf.constant([[-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_OrdinalAccuracy() -> None:
     loss = OrdinalAccuracy()
@@ -47,11 +57,13 @@ def test_OrdinalAccuracy() -> None:
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_SparseOrdinalAccuracy() -> None:
     loss = OrdinalAccuracy(sparse=True)
     val = loss(tf.constant([2]), tf.constant([[-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_OrdinalAccuracy1() -> None:
     loss = OrdinalAccuracy(tolerance=1)
@@ -59,11 +71,13 @@ def test_OrdinalAccuracy1() -> None:
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_SparseOrdinalAccuracy1() -> None:
     loss = OrdinalAccuracy(sparse=True, tolerance=1)
     val = loss(tf.constant([2]), tf.constant([[-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_OrdinalAccuracy2() -> None:
     loss = OrdinalAccuracy()
@@ -71,11 +85,13 @@ def test_OrdinalAccuracy2() -> None:
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_SparseOrdinalAccuracy2() -> None:
     loss = OrdinalAccuracy(sparse=True)
     val = loss(tf.constant([1]), tf.constant([[-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_OrdinalAccuracy12() -> None:
     loss = OrdinalAccuracy(tolerance=1)
@@ -83,106 +99,121 @@ def test_OrdinalAccuracy12() -> None:
     expect = tf.constant(1.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_SparseOrdinalAccuracy12() -> None:
     loss = OrdinalAccuracy(sparse=True, tolerance=1)
     val = loss(tf.constant([1]), tf.constant([[-1., 1.]]))
     expect = tf.constant(1.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_OrdinalMeanAbsoluteError3() -> None:
     loss = OrdinalMeanAbsoluteError()
-    val = loss(tf.constant([[1., 1.],[1., 1.]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[1., 1.], [1., 1.]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(2.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_SparseOrdinalMeanAbsoluteError3() -> None:
     loss = OrdinalMeanAbsoluteError(sparse=True)
-    val = loss(tf.constant([[2],[2]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[2], [2]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(2.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_OrdinalMeanAbsoluteError13() -> None:
     loss = OrdinalMeanAbsoluteError()
-    val = loss(tf.constant([[1., 0.],[1., 0.]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[1., 0.], [1., 0.]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(1.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_SparseOrdinalMeanAbsoluteError13() -> None:
     loss = OrdinalMeanAbsoluteError(sparse=True)
-    val = loss(tf.constant([[1],[1]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[1], [1]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(1.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_OrdinalMeanAbsoluteError23() -> None:
     loss = OrdinalMeanAbsoluteError()
-    val = loss(tf.constant([[0., 0.],[0., 0.]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[0., 0.], [0., 0.]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_SparseOrdinalMeanAbsoluteError23() -> None:
     loss = OrdinalMeanAbsoluteError(sparse=True)
-    val = loss(tf.constant([[0],[0]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[0], [0]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_OrdinalAccuracy3() -> None:
     loss = OrdinalAccuracy()
-    val = loss(tf.constant([[1., 1.],[1., 1.]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[1., 1.], [1., 1.]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_SparseOrdinalAccuracy3() -> None:
     loss = OrdinalAccuracy(sparse=True)
-    val = loss(tf.constant([[2],[2]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[2], [2]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_OrdinalAccuracy13() -> None:
     loss = OrdinalAccuracy(tolerance=1)
-    val = loss(tf.constant([[1., 1.],[1., 1.]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[1., 1.], [1., 1.]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_SparseOrdinalAccuracy13() -> None:
     loss = OrdinalAccuracy(sparse=True, tolerance=1)
-    val = loss(tf.constant([[2],[2]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[2], [2]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_OrdinalAccuracy23() -> None:
     loss = OrdinalAccuracy()
-    val = loss(tf.constant([[1., 0.],[1., 0.]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[1., 0.], [1., 0.]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
+
 
 def test_SparseOrdinalAccuracy23() -> None:
     loss = OrdinalAccuracy(sparse=True)
-    val = loss(tf.constant([[1],[1]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[1], [1]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_OrdinalAccuracy123() -> None:
     loss = OrdinalAccuracy(tolerance=1)
-    val = loss(tf.constant([[1., 0.],[1., 0.]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[1., 0.], [1., 0.]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(1.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
+
 def test_SparseOrdinalAccuracy123() -> None:
     loss = OrdinalAccuracy(sparse=True, tolerance=1)
-    val = loss(tf.constant([[1],[1]]),
-               tf.constant([[-1., 1.],[-1., 1.]]))
+    val = loss(tf.constant([[1], [1]]),
+               tf.constant([[-1., 1.], [-1., 1.]]))
     expect = tf.constant(1.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)

--- a/src/condor_tensorflow/tests/test_metrics.py
+++ b/src/condor_tensorflow/tests/test_metrics.py
@@ -1,9 +1,8 @@
-from condor_tensorflow.metrics import OrdinalMeanAbsoluteError
-from condor_tensorflow.metrics import SparseOrdinalMeanAbsoluteError
-from condor_tensorflow.metrics import OrdinalAccuracy
-from condor_tensorflow.metrics import SparseOrdinalAccuracy
 import pytest
 import tensorflow as tf
+
+from condor_tensorflow.metrics import OrdinalMeanAbsoluteError
+from condor_tensorflow.metrics import OrdinalAccuracy
 
 
 def test_OrdinalMeanAbsoluteError() -> None:
@@ -13,7 +12,7 @@ def test_OrdinalMeanAbsoluteError() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalMeanAbsoluteError() -> None:
-    loss = SparseOrdinalMeanAbsoluteError()
+    loss = OrdinalMeanAbsoluteError(sparse=True)
     val = loss(tf.constant([2]), tf.constant([[-1., 1.]]))
     expect = tf.constant(2.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
@@ -25,7 +24,7 @@ def test_OrdinalMeanAbsoluteError1() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalMeanAbsoluteError1() -> None:
-    loss = SparseOrdinalMeanAbsoluteError()
+    loss = OrdinalMeanAbsoluteError(sparse=True)
     val = loss(tf.constant([1]), tf.constant([[-1., 1.]]))
     expect = tf.constant(1.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
@@ -37,7 +36,7 @@ def test_OrdinalMeanAbsoluteError2() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalMeanAbsoluteError2() -> None:
-    loss = SparseOrdinalMeanAbsoluteError()
+    loss = OrdinalMeanAbsoluteError(sparse=True)
     val = loss(tf.constant([0]), tf.constant([[-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
@@ -49,7 +48,7 @@ def test_OrdinalAccuracy() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalAccuracy() -> None:
-    loss = SparseOrdinalAccuracy()
+    loss = OrdinalAccuracy(sparse=True)
     val = loss(tf.constant([2]), tf.constant([[-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
@@ -61,7 +60,7 @@ def test_OrdinalAccuracy1() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalAccuracy1() -> None:
-    loss = SparseOrdinalAccuracy(tolerance=1)
+    loss = OrdinalAccuracy(sparse=True, tolerance=1)
     val = loss(tf.constant([2]), tf.constant([[-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
@@ -73,7 +72,7 @@ def test_OrdinalAccuracy2() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalAccuracy2() -> None:
-    loss = SparseOrdinalAccuracy()
+    loss = OrdinalAccuracy(sparse=True)
     val = loss(tf.constant([1]), tf.constant([[-1., 1.]]))
     expect = tf.constant(0.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
@@ -85,14 +84,10 @@ def test_OrdinalAccuracy12() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalAccuracy12() -> None:
-    loss = SparseOrdinalAccuracy(tolerance=1)
+    loss = OrdinalAccuracy(sparse=True, tolerance=1)
     val = loss(tf.constant([1]), tf.constant([[-1., 1.]]))
     expect = tf.constant(1.0)
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
-
-
-
-
 
 def test_OrdinalMeanAbsoluteError3() -> None:
     loss = OrdinalMeanAbsoluteError()
@@ -102,7 +97,7 @@ def test_OrdinalMeanAbsoluteError3() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalMeanAbsoluteError3() -> None:
-    loss = SparseOrdinalMeanAbsoluteError()
+    loss = OrdinalMeanAbsoluteError(sparse=True)
     val = loss(tf.constant([[2],[2]]),
                tf.constant([[-1., 1.],[-1., 1.]]))
     expect = tf.constant(2.0)
@@ -116,7 +111,7 @@ def test_OrdinalMeanAbsoluteError13() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalMeanAbsoluteError13() -> None:
-    loss = SparseOrdinalMeanAbsoluteError()
+    loss = OrdinalMeanAbsoluteError(sparse=True)
     val = loss(tf.constant([[1],[1]]),
                tf.constant([[-1., 1.],[-1., 1.]]))
     expect = tf.constant(1.0)
@@ -130,7 +125,7 @@ def test_OrdinalMeanAbsoluteError23() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalMeanAbsoluteError23() -> None:
-    loss = SparseOrdinalMeanAbsoluteError()
+    loss = OrdinalMeanAbsoluteError(sparse=True)
     val = loss(tf.constant([[0],[0]]),
                tf.constant([[-1., 1.],[-1., 1.]]))
     expect = tf.constant(0.0)
@@ -144,7 +139,7 @@ def test_OrdinalAccuracy3() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalAccuracy3() -> None:
-    loss = SparseOrdinalAccuracy()
+    loss = OrdinalAccuracy(sparse=True)
     val = loss(tf.constant([[2],[2]]),
                tf.constant([[-1., 1.],[-1., 1.]]))
     expect = tf.constant(0.0)
@@ -158,7 +153,7 @@ def test_OrdinalAccuracy13() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalAccuracy13() -> None:
-    loss = SparseOrdinalAccuracy(tolerance=1)
+    loss = OrdinalAccuracy(sparse=True, tolerance=1)
     val = loss(tf.constant([[2],[2]]),
                tf.constant([[-1., 1.],[-1., 1.]]))
     expect = tf.constant(0.0)
@@ -172,7 +167,7 @@ def test_OrdinalAccuracy23() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalAccuracy23() -> None:
-    loss = SparseOrdinalAccuracy()
+    loss = OrdinalAccuracy(sparse=True)
     val = loss(tf.constant([[1],[1]]),
                tf.constant([[-1., 1.],[-1., 1.]]))
     expect = tf.constant(0.0)
@@ -186,7 +181,7 @@ def test_OrdinalAccuracy123() -> None:
     tf.debugging.assert_near(val, expect, rtol=1e-5, atol=1e-5)
 
 def test_SparseOrdinalAccuracy123() -> None:
-    loss = SparseOrdinalAccuracy(tolerance=1)
+    loss = OrdinalAccuracy(sparse=True, tolerance=1)
     val = loss(tf.constant([[1],[1]]),
                tf.constant([[-1., 1.],[-1., 1.]]))
     expect = tf.constant(1.0)

--- a/src/condor_tensorflow/version.py
+++ b/src/condor_tensorflow/version.py
@@ -1,1 +1,4 @@
+"""
+Version support module for Condor-TensorFlow
+"""
 __version__ = '1.1.0'


### PR DESCRIPTION
- use `sparse` boolean argument instead of repeating class definitions
- speed up encoder method  and EMD loss (avoid `map_fn` calls)
- register Keras serializables
- docstring, formatting, and typing fixes